### PR TITLE
Fixed a small nil reference issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/
 FS17_seasons*.zip
 node_modules/
 .cookies
+
+.vscode

--- a/src/environment/ssWeatherManager.lua
+++ b/src/environment/ssWeatherManager.lua
@@ -640,7 +640,7 @@ function ssWeatherManager:overwriteRaintable()
     local tmpWeather = {}
 
     for index = 1, self.forecastLength do
-        if self.weather[index].rainTypeId ~= "sun" then
+        if self.weather[index] ~= nil and self.weather[index].rainTypeId ~= "sun" then
             local tmpSingleWeather = deepCopy(self.weather[index])
             table.insert(tmpWeather, tmpSingleWeather)
         end


### PR DESCRIPTION
Hi guys, by playing with seasons mod active, I found a nil reference bug at line 643 of ssWeatherManager.
I'm not sure but I think it happens at midnight...
With commit c39d768 I've made a first fix but to definitely fix it, we should understand why the value is nil and not only checking if it is.
With commit be15662, I've only added a folder to .gitignore that is needed for who use VSCode.
