### PR TITLE
Field job manager dev

### DIFF
--- a/src/misc/ssFieldJobManager.lua
+++ b/src/misc/ssFieldJobManager.lua
@@ -75,10 +75,11 @@ function ssFieldJobManager.isFieldJobAllowed(fieldJob, isNPC)
     local currentGT = g_seasons.environment:growthTransitionAtDay()
     local env = g_seasons.environment
 
+    -- Use vanilla FieldJobManager if not using seasons growthManager
+    if not g_seasons.growthManager.growthManagerEnabled then return true end
+    
     -- Allow nothing when ground is frozen
-    if g_seasons.weather:isGroundFrozen() then
-        return false
-    end
+    if g_seasons.weather:isGroundFrozen() then return false end
 
     -- Always allow fertilizing missions, unless rain
     if fieldJob == FieldJob.TYPE_FERTILIZING_GROWING or fieldJob == FieldJob.TYPE_FERTILIZING_HARVESTED or fieldJob == FieldJob.TYPE_FERTILIZING_SOWN then

--- a/src/misc/ssFieldJobManager.lua
+++ b/src/misc/ssFieldJobManager.lua
@@ -85,15 +85,15 @@ function ssFieldJobManager.isFieldJobAllowed(fieldJob, isNPC)
     if fieldJob == FieldJob.TYPE_FERTILIZING_GROWING or fieldJob == FieldJob.TYPE_FERTILIZING_HARVESTED or fieldJob == FieldJob.TYPE_FERTILIZING_SOWN then
         return true
     -- Always allow user assigned missions to cultivate
-    -- NPC only cultivates in early-mid spring
+    -- NPC only cultivates in spring
     elseif fieldJob == FieldJob.TYPE_PLOUGHING or fieldJob == FieldJob.TYPE_CULTIVATING then
         if isNPC then
-            return currentGT >= env.TRANSITION_EARLY_SPRING and currentGT <= env.TRANSITION_MID_SPRING
+            return currentGT >= env.TRANSITION_EARLY_SPRING and currentGT <= env.TRANSITION_LATE_SPRING
         else
             return true
         end
     -- Never allow harvesting wet crop
-    -- NPC only harvests in mid autumn - early winter
+    -- NPC only harvests in late autumn
     -- Always allow user assigned missions to harvest
     elseif fieldJob == FieldJob.TYPE_HARVESTING then
         if g_seasons.weather:isCropWet() then
@@ -101,7 +101,7 @@ function ssFieldJobManager.isFieldJobAllowed(fieldJob, isNPC)
         end
 
         if isNPC then
-            return currentGT >= env.TRANSITION_MID_AUTUMN and currentGT <= env.TRANSITION_EARLY_WINTER
+            return currentGT == env.TRANSITION_LATE_AUTUMN
         else
             return true
         end

--- a/src/misc/ssFieldJobManager.lua
+++ b/src/misc/ssFieldJobManager.lua
@@ -81,9 +81,9 @@ function ssFieldJobManager.isFieldJobAllowed(fieldJob, isNPC)
     -- Allow nothing when ground is frozen
     if g_seasons.weather:isGroundFrozen() then return false end
 
-    -- Always allow fertilizing missions, unless rain
+    -- Always allow fertilizing missions
     if fieldJob == FieldJob.TYPE_FERTILIZING_GROWING or fieldJob == FieldJob.TYPE_FERTILIZING_HARVESTED or fieldJob == FieldJob.TYPE_FERTILIZING_SOWN then
-        return not (g_currentMission.environment.timeSinceLastRain == 0)
+        return true
     -- Always allow user assigned missions to cultivate
     -- NPC only cultivates in early-mid spring
     elseif fieldJob == FieldJob.TYPE_PLOUGHING or fieldJob == FieldJob.TYPE_CULTIVATING then


### PR DESCRIPTION
e6373dc1d1a1cba9131f7b20bd35545ee1f2a12b
- Narrowed NPC harvesting window to late-autumn, gives player an opportunity to harvesting field jobs, relying on the new more aggressive cropMositureContent algorithm to not have it wither.  
- Increased the the NPC cultivating window to allow re-seeding if seed (player seeded > GT3) did not germinate. 

632aeb5aac9fbbd57bb93afbdacb7b21d3652e8a
Allow fertilizing fieldJobs in rain

739d7162cc81ab035bc4874722cc94379a2e61db
Use vanilla FieldJobManager if not using seasons growthManager
