### PR TITLE
Implement a Skip night functionality.

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -32,6 +32,7 @@
         <input name="SEASONS_SHOW_WF" category="ONFOOT VEHICLE" key1="KEY_lalt KEY_f" key2="" button="" device="" mouse=""/>
         <input name="SEASONS_REPAIR_VEHICLE" category="ONFOOT" key1="KEY_lalt KEY_r" key2="" button="" device="" mouse=""/>
         <input name="SEASONS_SHOW_MENU" category="ONFOOT VEHICLE" key1="KEY_lalt KEY_s" key2="" button="" device="" mouse=""/>
+        <input name="SEASONS_SKIP_NIGHT" category="ONFOOT" key1="KEY_lalt KEY_n" key2="" button="" device="" mouse=""/>
     </inputBindings>
 
     <storeItems>

--- a/src/gui/ssCatchingUp.lua
+++ b/src/gui/ssCatchingUp.lua
@@ -13,7 +13,7 @@ ssCatchingUp = {}
 g_seasons.catchingUp = ssCatchingUp
 
 ssCatchingUp.LIMIT = 3
-ssCatchingUp.FFWD = 120
+ssCatchingUp.FFWD = 300
 
 function ssCatchingUp:loadMap()
     self.showWarning = false
@@ -33,12 +33,15 @@ function ssCatchingUp:update(dt)
         if g_seasons.dms.queue.size > ssCatchingUp.LIMIT and self.showWarning ~= true then
             local oldSize = g_seasons.dms.queue.size
 
-            self.showWarning = true
-
             self:foldJobs()
 
             logInfo("[ssCatchingUp] Game was fast forwarded: number of jobs is reduced from", oldSize, "to", g_seasons.dms.queue.size)
-        elseif g_seasons.dms.queue.size == 0 then
+
+            -- If after reduction the number of items is still more than the limit, show a warning
+            if g_seasons.dms.queue.size > ssCatchingUp.LIMIT then
+                self.showWarning = true
+            end
+        elseif g_seasons.dms.queue.size <= ssCatchingUp.LIMIT then
             -- Only stop when queue is empty for best effect
             self.showWarning = false
             self.didFfwd = false

--- a/src/loader.lua
+++ b/src/loader.lua
@@ -102,6 +102,7 @@ local files = {
     "misc/ssSwathManager",
     "misc/ssBaleManager",
     "misc/ssAnimals",
+    "misc/ssSkipNight",
 
     -- Adjusted objects
     "objects/ssBunkerSilo",

--- a/src/misc/ssSkipNight.lua
+++ b/src/misc/ssSkipNight.lua
@@ -1,0 +1,45 @@
+----------------------------------------------------------------------------------------------------
+-- SKIP NIGHT SCRIPT
+----------------------------------------------------------------------------------------------------
+-- Purpose:  Allows player to skip the night by fast forwarding to the morning.
+-- Authors:  Rahkiin
+--
+-- Copyright (c) Realismus Modding, 2017
+----------------------------------------------------------------------------------------------------
+
+ssSkipNight = {}
+g_seasons.skipNight = ssSkipNight
+
+ssSkipNight.SPEED = 10000
+
+function ssSkipNight:loadMap()
+    self.skippingNight = false
+end
+
+function ssSkipNight:update(dt)
+    -- Singleplayer only
+    if not g_currentMission:getIsServer() or not g_currentMission:getIsClient() then return end
+
+    local time = g_currentMission.environment.dayTime / 60 / 1000
+    local isEvening = time >= g_currentMission.environment.nightStart
+    local isMorning = time >= g_currentMission.environment.nightEnd and time < (12 * 60)
+
+    if isEvening then
+        g_currentMission:addHelpButtonText(g_i18n:getText("input_SEASONS_SKIP_NIGHT"), InputBinding.SEASONS_SKIP_NIGHT)
+
+        if InputBinding.hasEvent(InputBinding.SEASONS_SKIP_NIGHT) then
+            self.skippingNight = true
+
+            self.oldTimeScale = g_currentMission.missionInfo.timeScale
+            g_currentMission.missionInfo.timeScale = ssSkipNight.SPEED
+        end
+    end
+
+    -- When night ends, stop fast forwarding.
+    -- The ssCatchingUp code will synchronize
+    if self.skippingNight and isMorning then
+        self.skippingNight = false
+
+        g_currentMission.missionInfo.timeScale = self.oldTimeScale
+    end
+end

--- a/src/utils/ssDebug.lua
+++ b/src/utils/ssDebug.lua
@@ -48,7 +48,7 @@ function ssDebug:setEnabled(enabled)
         g_currentMission.environment:addHourChangeListener(self)
 
         self.oldTimeScale = g_currentMission.missionInfo.timeScale
-        g_currentMission:setTimeScale(60000)
+        g_currentMission:setTimeScale(6000)
     else
         g_currentMission.environment:removeMinuteChangeListener(self)
         g_currentMission.environment:removeHourChangeListener(self)

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Oprava vozidla" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Otevřít menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Vzdálenost rostlin" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Skrýt předpověď počasí" />
 
         <text name="SS_WEEKDAY_1" text="Pondělí" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Resetování růstu" />
         <text name="dialog_resetGrowth_no" text="Ponechat" />
         <text name="dialog_resetGrowth_yes" text="Resetovat" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Sníh" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Fahrzeug Reparieren" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Menü öffnen" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Pflanzabstand %d m " />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Wettervorhersage verbergen" />
 
         <text name="SS_WEEKDAY_1" text="Montag" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Neustart mit dem Seasons-Mod. Wachstum zurücksetzen?" />
         <text name="dialog_resetGrowth_no" text="Wachstum beibehalten" />
         <text name="dialog_resetGrowth_yes" text="Alle Wachstumsstufen zurücksetzen" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Schnee" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -5,11 +5,11 @@
     </translationContributors>
 
     <texts>
-        <!-- Control actions -->
         <text name="input_SEASONS_SHOW_WF" text="Seasons: Show weather forecast" />
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Repair vehicle" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Open menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Planting distance (%d m)" />
+        <text name="input_SEASONS_SKIP_NIGHT" text="Skip night" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Hide weather forecast" />
 
         <text name="SS_WEEKDAY_1" text="Monday" />
@@ -123,7 +123,7 @@
         <text name="dialog_resetGrowth_title" text="Growth reset" />
         <text name="dialog_resetGrowth_no" text="Keep growth" />
         <text name="dialog_resetGrowth_yes" text="Reset" />
-        <text name="dialog_timeTravel" text="The game is catching up to your time travelling" />
+        <text name="dialog_timeTravel" text="The game is synchronizing after the fast-forward" />
 
         <text name="fillType_snow" text="Snow" />
     </texts>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Reparar vehículo" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Abrir menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Falta %d m para sembrar" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Ocultar predicción tiempo" />
 
         <text name="SS_WEEKDAY_1" text="Lunes" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Resetear crecimiento" />
         <text name="dialog_resetGrowth_no" text="Mantener crecimiento" />
         <text name="dialog_resetGrowth_yes" text="Reset" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Nieve" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Réparation de véhicule" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Afficher le menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Distance de Plantation (%d m)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Cacher les prévisions" />
 
         <text name="SS_WEEKDAY_1" text="Lundi" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Remise a zéro dela croissance" />
         <text name="dialog_resetGrowth_no" text="maintenir la croissance" />
         <text name="dialog_resetGrowth_yes" text="réinitialisation" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Neige" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: gép / jármû javitása" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: menü megnyitás" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Vetési távolság (%d m)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: idõjárás elõrejelzés ki" />
 
         <text name="SS_WEEKDAY_1" text="Hétfõ" />
@@ -120,7 +122,7 @@
         <text name="dialog_resetGrowth_title" text="Növény növekedés alaphelyzetbe" />
         <text name="dialog_resetGrowth_no" text="Növény növekedés megtartása" />
         <text name="dialog_resetGrowth_yes" text="alaphelyzetbe" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Hó" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Ripara Veicolo" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Apri menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Distanza piantatrice (%d m)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Seasons: Nascondi previsioni del tempo" />
 
         <text name="SS_WEEKDAY_1" text="Lunedì" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Reset crescita" />
         <text name="dialog_resetGrowth_no" text="Mantieni la crescita" />
         <text name="dialog_resetGrowth_yes" text="Reset" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Neve" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seizoenen: Repareer voertuig" />
         <text name="input_SEASONS_SHOW_MENU" text="Seizoenen: Open menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Plantafstand (%d m)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Verberg weersvoorspelling" />
 
         <text name="SS_WEEKDAY_1" text="maandag" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Reset gewasgroei" />
         <text name="dialog_resetGrowth_no" text="Behoud gewasgroei" />
         <text name="dialog_resetGrowth_yes" text="Reset" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Sneeuw" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Sezony: Napraw pojazd" />
         <text name="input_SEASONS_SHOW_MENU" text="Sezony: Otwórz menu" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Odległość sadzenia (%d m)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Sezony: Ukryj prognozę pogody" />
 
         <text name="SS_WEEKDAY_1" text="Poniedziałek" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Resetowanie wzrostu upraw" />
         <text name="dialog_resetGrowth_no" text="Zachowaj uprawy" />
         <text name="dialog_resetGrowth_yes" text="Zresetuj" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Śnieg" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -6,6 +6,8 @@
         <text name="input_SEASONS_REPAIR_VEHICLE" text="Seasons: Ремонтировать технику" />
         <text name="input_SEASONS_SHOW_MENU" text="Seasons: Открыть меню" />
         <text name="input_SEASONS_PLANTING_DISTANCE" text="Расстояние посадки (%d м)" />
+        <!-- Missing translation of "Skip night" -->
+        <text name="input_SEASONS_SKIP_NIGHT" text="" />
         <text name="SEASONS_HIDE_WF" text="Скрыть прогноз погоды" />
 
         <text name="SS_WEEKDAY_1" text="Понедельник" />
@@ -118,7 +120,7 @@
         <text name="dialog_resetGrowth_title" text="Сброс состояния роста культур" />
         <text name="dialog_resetGrowth_no" text="Не сбрасывать" />
         <text name="dialog_resetGrowth_yes" text="Сбросить" />
-        <!-- Missing translation of "The game is catching up to your time travelling" -->
+        <!-- Missing translation of "The game is synchronizing after the fast-forward" -->
         <text name="dialog_timeTravel" text="" />
 
         <text name="fillType_snow" text="Снег" />


### PR DESCRIPTION
After the night starts, and you are on foot, you can choose to skip the night.
The game will then fast forward to the morning.

Closes #203