### PR TITLE
Improved fermentation of bales

### DIFF
--- a/src/misc/ssBaleManager.lua
+++ b/src/misc/ssBaleManager.lua
@@ -195,6 +195,7 @@ end
 
 -- from fatov - balewrapper determines what bales to ferment
 function ssBaleManager:baleWrapperPickupWrapperBale(bale, baleType)
+    -- from https://gdn.giants-software.com/documentation_scripting.php?version=script&category=70&class=3416#pickupWrapperBale46390
     log("Source bale fillType is:", FillUtil.fillTypeIndexToDesc[bale.fillType].nameI18N)
     if baleType ~= nil and bale.i3dFilename ~= baleType.wrapperBaleFilename then
         -- here is sure that the current bale supports the wrapping


### PR DESCRIPTION
The idea of setting *ssSilageSource* on bales was good. Unluckly, even if the "source" bale had this field setted, the wrapper replace the "source" bale with the correspondent wrappable bale then the *ssSilageSource* field go lost.
The solution I found consists in changing the "place" where we set the original fillType and we start the fermentation process, with this change, this happen when the wrapper replace the "source" bale the correspondent wrappable bale so that we know the source fillType, this will also make that function compatible with all kind of wrappable bales without the need of any integration from other mods.
I tested it with all kind of wrappers and it worked perfectly.