### PR TITLE
Crashfix when snow near border.

### DIFF
--- a/src/environment/ssSnow.lua
+++ b/src/environment/ssSnow.lua
@@ -159,6 +159,7 @@ function ssSnow:addSnow(startWorldX, startWorldZ, widthWorldX, widthWorldZ, heig
 
     -- Fix for broken vanilla game: when swath is very near the south border, the game crashes
     heightWorldZ = math.min(heightWorldZ, (g_currentMission.terrainSize / 2.0) - 18.0)
+    widthWorldX = math.min(widthWorldX, (g_currentMission.terrainSize / 2.0) - 18.0)
 
     local x, z, widthX, widthZ, heightX, heightZ = Utils.getXZWidthAndHeight(g_currentMission.terrainDetailHeightId, startWorldX, startWorldZ, widthWorldX, widthWorldZ, heightWorldX, heightWorldZ)
 


### PR DESCRIPTION
On my testmap with a 1024x1024 heightmap the game crashes when going close to the east border. Made this fix symetric with the one for the south border. There seams to be no problem at the west and north borders.

Where does the magic constant 18 come from? 